### PR TITLE
Fix retry button for failed missions and OutlineModification AttributeError

### DIFF
--- a/maestro_backend/ai_researcher/agentic_layer/controller/reflection_manager.py
+++ b/maestro_backend/ai_researcher/agentic_layer/controller/reflection_manager.py
@@ -268,8 +268,8 @@ class ReflectionManager:
                       all_suggestion_details.append(
                            # Use section_id from the tuple, not output.section_id
                            f"- Structural Modification Suggestion (for section '{section_id}'):\n"
-                           f"    Type='{mod.modification_type}', Target ID='{mod.target_section_id}', "
-                           f"New Title='{mod.new_title}', New Description='{mod.new_description}', "
+                           f"    Type='{mod.modification_type}', Target ID='{mod.details.section_id}', "
+                           f"New Title='{mod.details.new_title}', New Description='{mod.details.new_topic}', "
                            f"Reasoning='{mod.reasoning}'"
                       )
                       total_structural_suggestions += 1

--- a/maestro_backend/api/missions.py
+++ b/maestro_backend/api/missions.py
@@ -804,7 +804,7 @@ async def resume_mission_execution(
                 detail="Mission not found"
             )
 
-        if mission_context.status != "stopped":
+        if mission_context.status not in ["stopped", "failed"]:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Mission cannot be resumed. Current status: {mission_context.status}"


### PR DESCRIPTION
## Summary
- Fix retry button functionality to allow resuming failed missions
- Resolve OutlineModification AttributeError in reflection manager

## Changes
- **maestro_backend/api/missions.py**: Allow resume for both "stopped" and "failed" mission statuses
- **maestro_backend/ai_researcher/agentic_layer/controller/reflection_manager.py**: Fix attribute access to use mod.details.* pattern

## Test Plan
- [x] Verified retry button works for failed missions
- [x] Confirmed mission resumes properly without data loss
- [x] Database shows correct status transitions (failed → running)
- [x] No AttributeError exceptions in reflection agent processing