### PR TITLE
Update GPU detection to use newer CUDA base image

### DIFF
--- a/detect_gpu.sh
+++ b/detect_gpu.sh
@@ -18,7 +18,7 @@ detect_gpu() {
     # Check for NVIDIA GPU on Linux/Windows
     if command -v nvidia-smi &> /dev/null; then
         # Check if nvidia-container-toolkit is installed
-        if docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi &> /dev/null 2>&1; then
+        if docker run --rm --gpus all nvidia/cuda:12.9.1-base-ubuntu20.04 nvidia-smi &> /dev/null 2>&1; then
             echo "nvidia"
             return
         fi


### PR DESCRIPTION
## Summary
Updates GPU detection script to use newer CUDA base image for improved compatibility.

## Changes
- Update `detect_gpu.sh` to use `nvidia/cuda:12.9.1-base-ubuntu20.04` instead of `nvidia/cuda:11.0-base`
- Improves compatibility with newer GPU drivers and CUDA versions
- Maintains same functionality while supporting modern CUDA environments

## Testing
- GPU detection logic remains unchanged
- Should work with both older and newer NVIDIA GPU setups
- Backward compatible with existing GPU configurations