### PR TITLE
Fix: Update stop.sh script

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -7,11 +7,19 @@ echo "🛑 Stopping Maestro..."
 # Source GPU detection to determine which compose files were used
 source ./detect_gpu.sh
 
-if [ "$GPU_SUPPORT" = "nvidia" ]; then
-    COMPOSE_FILES="-f docker-compose.yml -f docker-compose.gpu.yml"
-else
-    COMPOSE_FILES="-f docker-compose.yml"
-fi
+# Define Docker Compose files based on GPU support
+COMPOSE_FILES=""
+case "$GPU_SUPPORT" in
+    "nvidia")
+        COMPOSE_FILES="-f docker-compose.yml -f docker-compose.gpu.yml"
+        ;;
+    "mac"|"cpu")
+        COMPOSE_FILES="-f docker-compose.cpu.yml"
+        ;;
+    *) # Default case for any other value, including unset
+        COMPOSE_FILES="-f docker-compose.yml"
+        ;;
+esac
 
 # Stop services
 docker compose $COMPOSE_FILES down


### PR DESCRIPTION
The stop.sh script failed to stop one of the containers on my Mac. Upon inspection, it was using COMPOSE_FILES="-f docker-compose.yml" instead of COMPOSE_FILES="-f docker-compose.cpu.yml"

I have updated the script to use COMPOSE_FILES="-f docker-compose.cpu.yml" for _cpu_ and _mac_ values of $GPU_SUPPORT, mirroring the behaviour of the start.sh script.

I have also updated the logic to use a _case_ construct for easier extendibility.